### PR TITLE
gx: update go-datastore

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.0.3: QmPdvXuXWAR6gtxxqZw42RtSADMwz4ijVmYHGS542b6cMz
+1.0.4: QmYnCBXxoyoS38vtNQjjpRwZTiUnpuuKpapxMNaDfyQRLf

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     },
     {
       "author": "jbenet",
-      "hash": "QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG",
+      "hash": "QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5",
       "name": "go-datastore",
-      "version": "1.2.2"
+      "version": "1.4.0"
     }
   ],
   "gxVersion": "0.8.0",
@@ -31,6 +31,6 @@
   "license": "",
   "name": "go-ds-leveldb",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.0.3"
+  "version": "1.0.4"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/whyrusleeping/failstore/pull/5
- https://github.com/whyrusleeping/retry-datastore/pull/4
- https://github.com/ipfs/go-ds-flatfs/pull/24
- https://github.com/ipfs/go-ds-measure/pull/11


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace