### PR TITLE
Feat: Implement the PersistentDatastore interface.

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -1,6 +1,10 @@
 package leveldb
 
 import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
 	ds "github.com/ipfs/go-datastore"
 	dsq "github.com/ipfs/go-datastore/query"
 	"github.com/jbenet/goprocess"
@@ -11,7 +15,10 @@ import (
 )
 
 type datastore struct {
-	DB *leveldb.DB
+	DB   *leveldb.DB
+	path string
+
+	diskUsage uint64
 }
 
 // Options is an alias of syndtr/goleveldb/opt.Options which might be extended
@@ -41,7 +48,9 @@ func NewDatastore(path string, opts *Options) (*datastore, error) {
 	}
 
 	return &datastore{
-		DB: db,
+		DB:        db,
+		path:      path,
+		diskUsage: 0,
 	}, nil
 }
 
@@ -54,6 +63,7 @@ func (d *datastore) Put(key ds.Key, value interface{}) (err error) {
 	if !ok {
 		return ds.ErrInvalidType
 	}
+	d.invalidateDiskUsage()
 	return d.DB.Put(key.Bytes(), val, nil)
 }
 
@@ -83,6 +93,7 @@ func (d *datastore) Delete(key ds.Key) (err error) {
 	} else if err != nil {
 		return err
 	}
+	d.invalidateDiskUsage()
 	return d.DB.Delete(key.Bytes(), nil)
 }
 
@@ -200,6 +211,41 @@ func (d *datastore) runQuery(worker goprocess.Process, qrb *dsq.ResultBuilder) {
 	}
 }
 
+func (d *datastore) invalidateDiskUsage() {
+	atomic.StoreUint64(&d.diskUsage, 0)
+}
+
+// DiskUsage returns the current disk size used by this levelDB.
+// For in-mem datastores, it will return 0.
+func (d *datastore) DiskUsage() (uint64, error) {
+	if d.path == "" { // in-mem
+		return 0, nil
+	}
+
+	cachedDu := atomic.LoadUint64(&d.diskUsage)
+
+	if cachedDu == 0 { // no-cached value
+		var du uint64
+
+		err := filepath.Walk(d.path, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			du += uint64(info.Size())
+			return nil
+		})
+
+		if err != nil {
+			return 0, err
+		}
+
+		atomic.StoreUint64(&d.diskUsage, du)
+		return du, nil
+	}
+
+	return cachedDu, nil
+}
+
 // LevelDB needs to be closed.
 func (d *datastore) Close() (err error) {
 	return d.DB.Close()
@@ -208,14 +254,16 @@ func (d *datastore) Close() (err error) {
 func (d *datastore) IsThreadSafe() {}
 
 type leveldbBatch struct {
-	b  *leveldb.Batch
-	db *leveldb.DB
+	b     *leveldb.Batch
+	db    *leveldb.DB
+	invDu func()
 }
 
 func (d *datastore) Batch() (ds.Batch, error) {
 	return &leveldbBatch{
-		b:  new(leveldb.Batch),
-		db: d.DB,
+		b:     new(leveldb.Batch),
+		db:    d.DB,
+		invDu: d.invalidateDiskUsage,
 	}, nil
 }
 
@@ -230,6 +278,7 @@ func (b *leveldbBatch) Put(key ds.Key, value interface{}) error {
 }
 
 func (b *leveldbBatch) Commit() error {
+	b.invDu()
 	return b.db.Write(b.b, nil)
 }
 

--- a/ds_test.go
+++ b/ds_test.go
@@ -210,14 +210,10 @@ func TestDiskUsage(t *testing.T) {
 
 	done()
 
-	// This works because it's using the cached value
-	du3, err := d.DiskUsage()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if du3 != du2 {
-		t.Fatal("expected to return the cached disk usage value")
+	// This should fail
+	_, err = d.DiskUsage()
+	if err == nil {
+		t.Fatal("DiskUsage should fail when we cannot walk path")
 	}
 }
 


### PR DESCRIPTION
This adds the DiskUsage() method. It caches the resulting value
and invalidates this cache on writes.