### PR TITLE
Fix broken documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It uses [Gx](https://github.com/whyrusleeping/gx) to manage dependencies. You ca
 import "github.com/ipfs/go-ds-leveldb"
 ```
 
-Check the [GoDoc documentation](https://godoc.org/github.com/ipfs/go-ds-lebeldb)
+Check the [GoDoc documentation](https://godoc.org/github.com/ipfs/go-ds-leveldb)
 
 
 ## Contribute


### PR DESCRIPTION
There was a typo in the URL for the documentation.