### PR TITLE
Bypass naive ordering when ordering by key (natural leveldb order)

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -174,6 +174,14 @@ func (a *accessor) queryOrig(q dsq.Query) (dsq.Results, error) {
 		qr = dsq.NaiveFilter(qr, f)
 	}
 	for _, o := range q.Orders {
+		// leveldb iterators return entries sorted lexicographically by key, so we can bypass the naive ordering
+		// for OrderByKey. Since OrderByKey.Sort() has as struct receiver, the value stored in q.Orders can be a
+		// pointer or a struct, so we need to check for both for correctness.
+		if _, ok := o.(dsq.OrderByKey); ok {
+			continue
+		} else if _, ok = o.(*dsq.OrderByKey); ok {
+			continue
+		}
 		qr = dsq.NaiveOrder(qr, o)
 	}
 	return qr, nil

--- a/datastore.go
+++ b/datastore.go
@@ -177,9 +177,8 @@ func (a *accessor) queryOrig(q dsq.Query) (dsq.Results, error) {
 		// leveldb iterators return entries sorted lexicographically by key, so we can bypass the naive ordering
 		// for OrderByKey. Since OrderByKey.Sort() has as struct receiver, the value stored in q.Orders can be a
 		// pointer or a struct, so we need to check for both for correctness.
-		if _, ok := o.(dsq.OrderByKey); ok {
-			continue
-		} else if _, ok = o.(*dsq.OrderByKey); ok {
+		switch o.(type) {
+		case dsq.OrderByKey, *dsq.OrderByKey:
 			continue
 		}
 		qr = dsq.NaiveOrder(qr, o)


### PR DESCRIPTION
Equivalent of https://github.com/ipfs/go-ds-badger/pull/43 for leveldb, but simplified, as leveldb iterators don't allow specifying reverse order.

Needed for correctness in https://github.com/libp2p/go-libp2p-peerstore/pull/47