### PR TITLE
wire a context in most of the Datastore methods

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -1,6 +1,7 @@
 package leveldb
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -79,17 +80,17 @@ type accessor struct {
 	closeLk    *sync.RWMutex
 }
 
-func (a *accessor) Put(key ds.Key, value []byte) (err error) {
+func (a *accessor) Put(ctx context.Context, key ds.Key, value []byte) (err error) {
 	a.closeLk.RLock()
 	defer a.closeLk.RUnlock()
 	return a.ldb.Put(key.Bytes(), value, &opt.WriteOptions{Sync: a.syncWrites})
 }
 
-func (a *accessor) Sync(prefix ds.Key) error {
+func (a *accessor) Sync(ctx context.Context, prefix ds.Key) error {
 	return nil
 }
 
-func (a *accessor) Get(key ds.Key) (value []byte, err error) {
+func (a *accessor) Get(ctx context.Context, key ds.Key) (value []byte, err error) {
 	a.closeLk.RLock()
 	defer a.closeLk.RUnlock()
 	val, err := a.ldb.Get(key.Bytes(), nil)
@@ -102,23 +103,23 @@ func (a *accessor) Get(key ds.Key) (value []byte, err error) {
 	return val, nil
 }
 
-func (a *accessor) Has(key ds.Key) (exists bool, err error) {
+func (a *accessor) Has(ctx context.Context, key ds.Key) (exists bool, err error) {
 	a.closeLk.RLock()
 	defer a.closeLk.RUnlock()
 	return a.ldb.Has(key.Bytes(), nil)
 }
 
-func (a *accessor) GetSize(key ds.Key) (size int, err error) {
-	return ds.GetBackedSize(a, key)
+func (a *accessor) GetSize(ctx context.Context, key ds.Key) (size int, err error) {
+	return ds.GetBackedSize(ctx, a, key)
 }
 
-func (a *accessor) Delete(key ds.Key) (err error) {
+func (a *accessor) Delete(ctx context.Context, key ds.Key) (err error) {
 	a.closeLk.RLock()
 	defer a.closeLk.RUnlock()
 	return a.ldb.Delete(key.Bytes(), &opt.WriteOptions{Sync: a.syncWrites})
 }
 
-func (a *accessor) Query(q dsq.Query) (dsq.Results, error) {
+func (a *accessor) Query(ctx context.Context, q dsq.Query) (dsq.Results, error) {
 	a.closeLk.RLock()
 	defer a.closeLk.RUnlock()
 	var rnge *util.Range
@@ -222,18 +223,18 @@ func (d *Datastore) Batch() (ds.Batch, error) {
 	}, nil
 }
 
-func (b *leveldbBatch) Put(key ds.Key, value []byte) error {
+func (b *leveldbBatch) Put(ctx context.Context, key ds.Key, value []byte) error {
 	b.b.Put(key.Bytes(), value)
 	return nil
 }
 
-func (b *leveldbBatch) Commit() error {
+func (b *leveldbBatch) Commit(ctx context.Context) error {
 	b.closeLk.RLock()
 	defer b.closeLk.RUnlock()
 	return b.db.Write(b.b, &opt.WriteOptions{Sync: b.syncWrites})
 }
 
-func (b *leveldbBatch) Delete(key ds.Key) error {
+func (b *leveldbBatch) Delete(ctx context.Context, key ds.Key) error {
 	b.b.Delete(key.Bytes())
 	return nil
 }
@@ -244,13 +245,13 @@ type transaction struct {
 	tx *leveldb.Transaction
 }
 
-func (t *transaction) Commit() error {
+func (t *transaction) Commit(ctx context.Context) error {
 	t.closeLk.RLock()
 	defer t.closeLk.RUnlock()
 	return t.tx.Commit()
 }
 
-func (t *transaction) Discard() {
+func (t *transaction) Discard(ctx context.Context) {
 	t.closeLk.RLock()
 	defer t.closeLk.RUnlock()
 	t.tx.Discard()


### PR DESCRIPTION
Master issue: https://github.com/ipfs/go-ipfs/issues/6803

This only do the wiring. Actual usage for cancellation, logging or tracing is
left for a future work.