### PR TITLE
fix closing of datastore in tests

### DIFF
--- a/ds_test.go
+++ b/ds_test.go
@@ -40,8 +40,12 @@ func newDS(t *testing.T) (*Datastore, func()) {
 		t.Fatal(err)
 	}
 	return d, func() {
-		os.RemoveAll(path)
-		d.Close()
+		if err := d.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.RemoveAll(path); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #51.

On Windows, we can't remove a directory if another process is still accessing it.